### PR TITLE
Convert HTML template to Next.js

### DIFF
--- a/nextjs-dopetrop/src/__tests__/Banner.test.tsx
+++ b/nextjs-dopetrop/src/__tests__/Banner.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from "@testing-library/react";
+import Banner from "../components/Banner";
+
+test("heading text", () => {
+  render(<Banner />);
+  expect(screen.getByRole("heading", { name: /howdy/i })).toBeInTheDocument();
+});

--- a/nextjs-dopetrop/src/__tests__/Header.test.tsx
+++ b/nextjs-dopetrop/src/__tests__/Header.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from "@testing-library/react";
+import Header from "../components/Header";
+
+it("renders navigation links", () => {
+  render(<Header />);
+  expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "Left Sidebar" })).toBeInTheDocument();
+});

--- a/nextjs-dopetrop/src/app/layout.tsx
+++ b/nextjs-dopetrop/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +26,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Header />
+        <main>{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/nextjs-dopetrop/src/app/left-sidebar/page.tsx
+++ b/nextjs-dopetrop/src/app/left-sidebar/page.tsx
@@ -1,0 +1,13 @@
+import Sidebar from "@/components/Sidebar";
+
+export default function LeftSidebar() {
+  return (
+    <div className="container mx-auto py-12 grid md:grid-cols-[200px_1fr] gap-6">
+      <Sidebar />
+      <article>
+        <h1 className="text-2xl font-bold mb-4">Left Sidebar</h1>
+        <p>This page demonstrates a layout with the sidebar on the left.</p>
+      </article>
+    </div>
+  );
+}

--- a/nextjs-dopetrop/src/app/no-sidebar/page.tsx
+++ b/nextjs-dopetrop/src/app/no-sidebar/page.tsx
@@ -1,0 +1,8 @@
+export default function NoSidebar() {
+  return (
+    <div className="container mx-auto py-12">
+      <h1 className="text-2xl font-bold mb-4">No Sidebar</h1>
+      <p>This page demonstrates a layout without any sidebar.</p>
+    </div>
+  );
+}

--- a/nextjs-dopetrop/src/app/page.tsx
+++ b/nextjs-dopetrop/src/app/page.tsx
@@ -1,103 +1,15 @@
-import Image from "next/image";
+import Banner from "@/components/Banner";
+import Intro from "@/components/Intro";
+import Portfolio from "@/components/Portfolio";
+import BlogList from "@/components/BlogList";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <>
+      <Banner />
+      <Intro />
+      <Portfolio />
+      <BlogList />
+    </>
   );
 }

--- a/nextjs-dopetrop/src/app/right-sidebar/page.tsx
+++ b/nextjs-dopetrop/src/app/right-sidebar/page.tsx
@@ -1,0 +1,13 @@
+import Sidebar from "@/components/Sidebar";
+
+export default function RightSidebar() {
+  return (
+    <div className="container mx-auto py-12 grid md:grid-cols-[1fr_200px] gap-6">
+      <article>
+        <h1 className="text-2xl font-bold mb-4">Right Sidebar</h1>
+        <p>This page demonstrates a layout with the sidebar on the right.</p>
+      </article>
+      <Sidebar />
+    </div>
+  );
+}

--- a/nextjs-dopetrop/src/components/Banner.tsx
+++ b/nextjs-dopetrop/src/components/Banner.tsx
@@ -1,0 +1,8 @@
+export default function Banner() {
+  return (
+    <section className="py-12 text-center bg-muted">
+      <h2 className="text-3xl font-bold mb-2">Howdy. This is Dopetrope.</h2>
+      <p className="text-muted-foreground">A responsive template converted to Next.js</p>
+    </section>
+  );
+}

--- a/nextjs-dopetrop/src/components/BlogList.tsx
+++ b/nextjs-dopetrop/src/components/BlogList.tsx
@@ -1,0 +1,13 @@
+import BlogPostCard from "./BlogPostCard";
+
+export default function BlogList() {
+  return (
+    <section className="container mx-auto py-12">
+      <h2 className="text-2xl font-bold mb-6">The Blog</h2>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <BlogPostCard title="Magna tempus consequat" image="/next.svg" />
+        <BlogPostCard title="Aptent veroeros aliquam" image="/next.svg" />
+      </div>
+    </section>
+  );
+}

--- a/nextjs-dopetrop/src/components/BlogPostCard.tsx
+++ b/nextjs-dopetrop/src/components/BlogPostCard.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function BlogPostCard({
+  title,
+  image,
+}: {
+  title: string;
+  image: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <Image src={image} alt={title} width={400} height={300} className="w-full h-auto" />
+        <h3 className="text-lg font-semibold mt-2">{title}</h3>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm mb-4">Lorem ipsum dolor sit amet sit veroeros et blandit.</p>
+        <Button variant="outline" size="sm">Continue Reading</Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/nextjs-dopetrop/src/components/FeatureCard.tsx
+++ b/nextjs-dopetrop/src/components/FeatureCard.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ReactNode } from "react";
+
+export default function FeatureCard({
+  title,
+  children,
+  icon,
+}: {
+  title: string;
+  children: ReactNode;
+  icon: ReactNode;
+}) {
+  return (
+    <Card className="text-center">
+      <CardHeader className="flex flex-col items-center gap-2">
+        {icon}
+        <h3 className="text-lg font-semibold">{title}</h3>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-4">{children}</p>
+        <Badge variant="outline">Learn More</Badge>
+      </CardContent>
+    </Card>
+  );
+}

--- a/nextjs-dopetrop/src/components/Footer.tsx
+++ b/nextjs-dopetrop/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="py-8 border-t mt-12 text-center text-sm text-muted-foreground">
+      &copy; Untitled. Design: HTML5 UP
+    </footer>
+  );
+}

--- a/nextjs-dopetrop/src/components/Header.tsx
+++ b/nextjs-dopetrop/src/components/Header.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
+
+export default function Header() {
+  return (
+    <header className="py-4 border-b">
+      <div className="container mx-auto flex justify-between items-center">
+        <Link href="/" className="text-xl font-bold">
+          Dopetrope
+        </Link>
+        <NavigationMenu>
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <Link href="/" legacyBehavior passHref>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  Home
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <Link href="/left-sidebar" legacyBehavior passHref>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  Left Sidebar
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <Link href="/right-sidebar" legacyBehavior passHref>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  Right Sidebar
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <Link href="/no-sidebar" legacyBehavior passHref>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  No Sidebar
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
+    </header>
+  );
+}

--- a/nextjs-dopetrop/src/components/Intro.tsx
+++ b/nextjs-dopetrop/src/components/Intro.tsx
@@ -1,0 +1,18 @@
+import { LucideBolt, LucideCog, LucideStar } from "lucide-react";
+import FeatureCard from "./FeatureCard";
+
+export default function Intro() {
+  return (
+    <section className="container mx-auto py-12 grid gap-6 sm:grid-cols-3">
+      <FeatureCard title="Ipsum consequat" icon={<LucideCog className="h-8 w-8" />}>
+        Nisl amet dolor sit ipsum veroeros sed blandit consequat veroeros et magna tempus.
+      </FeatureCard>
+      <FeatureCard title="Magna etiam dolor" icon={<LucideBolt className="h-8 w-8" />}>
+        Nisl amet dolor sit ipsum veroeros sed blandit consequat veroeros et magna tempus.
+      </FeatureCard>
+      <FeatureCard title="Tempus adipiscing" icon={<LucideStar className="h-8 w-8" />}>
+        Nisl amet dolor sit ipsum veroeros sed blandit consequat veroeros et magna tempus.
+      </FeatureCard>
+    </section>
+  );
+}

--- a/nextjs-dopetrop/src/components/Portfolio.tsx
+++ b/nextjs-dopetrop/src/components/Portfolio.tsx
@@ -1,0 +1,20 @@
+import PortfolioItem from "./PortfolioItem";
+
+export default function Portfolio() {
+  return (
+    <section className="container mx-auto py-12">
+      <h2 className="text-2xl font-bold mb-6">My Portfolio</h2>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <PortfolioItem title="Project One" image="/next.svg">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </PortfolioItem>
+        <PortfolioItem title="Project Two" image="/next.svg">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </PortfolioItem>
+        <PortfolioItem title="Project Three" image="/next.svg">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </PortfolioItem>
+      </div>
+    </section>
+  );
+}

--- a/nextjs-dopetrop/src/components/PortfolioItem.tsx
+++ b/nextjs-dopetrop/src/components/PortfolioItem.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { ReactNode } from "react";
+
+export default function PortfolioItem({
+  title,
+  image,
+  children,
+}: {
+  title: string;
+  image: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <Image src={image} alt={title} width={400} height={300} className="w-full h-auto" />
+        <h3 className="text-lg font-semibold mt-2">{title}</h3>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}

--- a/nextjs-dopetrop/src/components/Sidebar.tsx
+++ b/nextjs-dopetrop/src/components/Sidebar.tsx
@@ -1,0 +1,12 @@
+export default function Sidebar() {
+  return (
+    <aside className="border p-4 sticky top-4">
+      <h3 className="font-semibold mb-2">Sidebar</h3>
+      <ul className="space-y-1 text-sm">
+        <li><a href="#" className="underline">Lorem ipsum dolor</a></li>
+        <li><a href="#" className="underline">Feugiat consequat</a></li>
+        <li><a href="#" className="underline">Amet tempus</a></li>
+      </ul>
+    </aside>
+  );
+}

--- a/nextjs-dopetrop/tests/navigation.spec.ts
+++ b/nextjs-dopetrop/tests/navigation.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+const base = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000';
+
+test('home page loads', async ({ page }) => {
+  await page.goto(base);
+  await expect(page.getByRole('heading', { name: /howdy/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add layout wrappers with Header and Footer
- implement Banner, Intro and supporting components
- add sidebar pages and blog/portfolio sections
- create basic Jest and Playwright tests

## Testing
- `npm run build` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ed1f941b08322a3d6c71892f6c4d3